### PR TITLE
Fix undefined _system_name :ant:

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict';
 const fetch = require('isomorphic-fetch');
 const nightlyVersions = require('node-nightly-versions');
-const nightlyURL = (process.env.NODEJS_ORG_NIGHTLY_MIRROR || 
-  'https://nodejs.org/download/nightly') + '/index.tab';
-const osArch = `${process.env._system_name.toLowerCase()}-${process.arch}`;
+const osArch = `${process.platform}-${process.arch}`;
 const winVerMap = {
   'win-x64':'win-x64-exe',
   'win-x86':'win-x86-exe',
-  'osx-x64':'osx-x64-pkg'
+  'darwin-x64':'os-x64-pkg',//darwin is os name for osx
+  'darwin-x86':'os-x86-tar'
 }
 
 module.exports = () => nightlyVersions()


### PR DESCRIPTION
It was not an error but i think you just expected users to set a environment variables and they did not did that which was right on their part because of lack of documentation for the same. 👅 

This tries to fix that user dependency.
