### PR TITLE
Fix x86 -> ia32

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@ const nightlyVersions = require('node-nightly-versions');
 const osArch = `${process.platform}-${process.arch}`;
 const osVerMap = {
   'win32-x64':'win-x64-msi',
-  'win32-x86':'win-x86-msi',
+  'win32-ia32':'win-x86-msi',
   'darwin-x64':'osx-x64-pkg',//darwin is os name for osx
-  'darwin-x86':'osx-x86-tar',
+  'darwin-ia32':'osx-x86-tar',
   'linux-x64':'linux-x64',
-  'linux-x86':'linux-x86',
+  'linux-ia32':'linux-x86',
   'sunos-x64':'sunos-x64',
-  'sunos-x86':'sunos-x86'
+  'sunos-ia32':'sunos-x86'
 }
 
 module.exports = () => nightlyVersions()


### PR DESCRIPTION
I assume this is always process.arch and there isn't some case where it's actually x86.
